### PR TITLE
Replaced party bullets with black bolts

### DIFF
--- a/Items/Weapons/ZenithGun/ZenithGun.cs
+++ b/Items/Weapons/ZenithGun/ZenithGun.cs
@@ -115,7 +115,7 @@ namespace ZenithGun.Items.Weapons.ZenithGun {
 				typeList.Add(ProjectileID.BulletHighVelocity);
 				typeList.Add(ProjectileID.IchorBullet);
 				typeList.Add(ProjectileID.VenomBullet);
-				typeList.Add(ProjectileID.PartyBullet);
+				typeList.Add(ProjectileID.BlackBolt);
 				typeList.Add(ProjectileID.NanoBullet);
 				typeList.Add(ProjectileID.Bullet);
 				typeList.Add(ProjectileID.GoldenBullet);

--- a/build.txt
+++ b/build.txt
@@ -1,3 +1,3 @@
 displayName = Zenith Gun
-author = FabulousAmpharos (Ported by Auriwave)
-version = 1.1
+author = FabulousAmpharos (Auriwave - main porter, CyberSteve777 - contributor)
+version = 1.2


### PR DESCRIPTION
I really don't see a point for firing party bullets when Zenith gun has no party weapons. But we have an Onyx blaster with its own unique projectile, so why not using it instead?